### PR TITLE
Fix new format scoreboard for short tuples

### DIFF
--- a/go/payments/pkg/prolly_cellwise/diff_attributor.go
+++ b/go/payments/pkg/prolly_cellwise/diff_attributor.go
@@ -37,6 +37,7 @@ type diffAttributor struct {
 	logger           *zap.Logger
 	format           *types.NomsBinFormat
 	kd               val.TupleDesc
+	vd               val.TupleDesc
 	attVd            val.TupleDesc
 
 	newData       int
@@ -75,6 +76,7 @@ func newDiffAttributor(
 	}
 
 	kd, attVd := getAttribDescriptorsFromTblSchema(tblSch)
+	vd := tblSch.GetValueDescriptor()
 
 	return &diffAttributor{
 		tblSch:    tblSch,
@@ -86,6 +88,7 @@ func newDiffAttributor(
 		logger:    logger,
 		format:    format,
 		kd:        kd,
+		vd:        vd,
 		attVd:     attVd,
 	}, nil
 }
@@ -183,7 +186,7 @@ func (dA *diffAttributor) createAttrib(ctx context.Context, diff tree.Diff) erro
 	}
 
 	ra := make(prollyRowAtt, dA.attVd.Count())
-	err := ra.updateFromDiff(dA.kd, dA.commitIdx, diff)
+	err := ra.updateFromDiff(dA.kd, dA.vd, dA.commitIdx, diff)
 	if err != nil {
 		return err
 	}
@@ -214,7 +217,7 @@ func (dA *diffAttributor) updateAttrib(ctx context.Context, diff tree.Diff, attV
 
 	ra := prollyRowAttFromValue(dA.attVd, attVal)
 
-	err := ra.updateFromDiff(dA.kd, dA.commitIdx, diff)
+	err := ra.updateFromDiff(dA.kd, dA.vd, dA.commitIdx, diff)
 	if err != nil {
 		return err
 	}

--- a/go/payments/pkg/prolly_cellwise/prolly_cellwise_test.go
+++ b/go/payments/pkg/prolly_cellwise/prolly_cellwise_test.go
@@ -19,26 +19,26 @@ func getCellwiseExpected() [][]uint64 {
 	var expected [][]uint64
 
 	// Expected Scoreboard:
-	// Commit A: 2*1000 new = 2000
-	expected = append(expected, []uint64{2000})
+	// Commit A: 1000 new = 2000
+	expected = append(expected, []uint64{1000})
 
 	// Expected Scoreboard:
-	// Commit A: 2000 - (2*100 deleted + 1*100 col1 changes) = 1700
+	// Commit A: 1000 - (1*100 deleted + 1*100 col1 changes) = 800
 	// Commit B: 3*100 new + (2 * 100 changed) = 500
-	expected = append(expected, []uint64{1700, 500})
+	expected = append(expected, []uint64{800, 500})
 
 	// Expected Scoreboard:
-	// Commit A: 1700 - (1*100 deleted + 1*50 col1 changes) = 1550
+	// Commit A: 800 - (1*50 col1 changes) = 750
 	// Commit B: 500 - (2*100 deleted + 2*50 col1/col2 changes) = 200
 	// Commit C: 4*100 new + (3 * 100 changed) = 700
-	expected = append(expected, []uint64{1550, 200, 700})
+	expected = append(expected, []uint64{750, 200, 700})
 
 	// Expected Scoreboard:
-	// Commit A: 1550
+	// Commit A: 750
 	// Commit B: 200
 	// Commit C: 700 - (3*50 col1/col2/col3 changes = 550
 	// Commit D: 3*50 col1/col2/col3 changes in 1000-1050 + 1*50 col3 changes in 1050-1100 = 400
-	expected = append(expected, []uint64{1550, 200, 550, 200})
+	expected = append(expected, []uint64{750, 200, 550, 200})
 
 	return expected
 }
@@ -104,6 +104,13 @@ func TestProllyAttribution(t *testing.T) {
 
 			var prevSummary att.Summary = emptySummary(startOfBountyHash)
 			var prevCommit *doltdb.Commit
+			startCommit := commits[0]
+
+			if startCommit.NumParents() != 0 {
+				prevCommit, err = startCommit.GetParent(ctx, 0)
+				require.NoError(t, err)
+			}
+
 			for i := 0; i < len(expected); i++ {
 				commit := commits[i]
 				require.NoError(t, err)

--- a/go/payments/pkg/prolly_cellwise/row_attribution.go
+++ b/go/payments/pkg/prolly_cellwise/row_attribution.go
@@ -57,8 +57,8 @@ func (ra prollyRowAtt) updateFromDiff(kd, vd val.TupleDesc, commitIdx int16, dif
 		v := val.Tuple(difference.To)
 
 		// Set non-null fields as current owner
-		for i := 0; i < v.Count(); i++ {
-			if !v.FieldIsNull(i) {
+		for i := 0; i < vd.Count(); i++ {
+			if !vd.IsNull(i, v) {
 				ra[numPks+i] = &ci
 			} else {
 				ra[numPks+i] = nil


### PR DESCRIPTION
If a column is added to a table's schema by default the column will be added to the end of the table.
This does not perform a table rewrite, so in some cases prolly.Map's will have value tuples where its
`Count()` is shorter than the prolly.Map's value tuple description's count. 

This PR addresses that by using the value descriptor to access the tuple fields instead of the tuple
themselves. This handles any short tuples.